### PR TITLE
Run condition and input pin scripts on execute

### DIFF
--- a/src/flowTypes.ts
+++ b/src/flowTypes.ts
@@ -229,6 +229,18 @@ export class InputPin extends BasePin {
     // Otherwise always 1: returning to our owner
     return 1;
   }
+
+  execute(context: ExecuteContext): void {
+    runScript(
+      this.properties.Text,
+      context.variables,
+      context.visits,
+      this.id,
+      this.db,
+      true,
+      false
+    );
+  }
 }
 
 /**
@@ -320,6 +332,19 @@ export class Condition<
   // Always one branch. True or False.
   numBranches(): number {
     return 1;
+  }
+
+  // Execute in case of side effects
+  execute(context: ExecuteContext): void {
+    runScript(
+      this.properties.Expression,
+      context.variables,
+      context.visits,
+      this.id,
+      this.db,
+      true,
+      false
+    );
   }
 }
 


### PR DESCRIPTION
Originally, we were only running condition and input pin scripts on branch discovery, not branch execution. This was fine if conditions and input pins never contained scripts with side-effects, but isn't the case if they have them.

Came up when a function with a return value had a side effect when not shadowing.